### PR TITLE
Fix Roboto descenders

### DIFF
--- a/src/Feature/CopyrightNotice.php
+++ b/src/Feature/CopyrightNotice.php
@@ -74,7 +74,7 @@ class CopyrightNotice implements FeatureInterface
         $watermarkBackground = $imageManager->canvas($size['width'] + 10, $size['height'] + 5, $this->BackgroundColor);
         $watermark = $imageManager->canvas($size['width'], $size['height']);
 
-        $font->applyToImage($watermark, 0, 2);
+        $font->applyToImage($watermark, 0, 0);
 
         $watermarkBackground->insert($watermark, 'center');
 


### PR DESCRIPTION
When used with the example Roboto font, the Y offset pushes the descenders of the font below the canvas edge and they get cut off. Removing this fixes the issue.